### PR TITLE
Fix README file extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 license = "BSD-3-Clause"
 authors = ["Thomas Mansencal <thomas.mansencal@gmail.com>"]
-readme = "README.md"
+readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = ">= 3.10, < 4"


### PR DESCRIPTION
Unless you're planning to go back to the Markdown version, here's a quick fix that was previously causing the `poetry install` function to fail due to incorrect extension.

Cheers!